### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@v0.7.3
+      uses: saadmk11/github-actions-version-updater@v0.7.4
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -39,7 +39,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -54,7 +54,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.4.0](https://github.com/actions/checkout/releases/tag/v3.4.0)** on 2023-03-15T19:47:24Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
