### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -39,7 +39,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -54,7 +54,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
