### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.7
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.0
+      uses: actions/setup-python@v5.1.1
       with:
         python-version: 3.8
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.7
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.7
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -39,7 +39,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.7
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -54,7 +54,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.7
 
     - name: Set up rust toolchain
       uses: actions-rs/toolchain@v1.0.6
@@ -67,7 +67,7 @@ jobs:
         cargo tarpaulin --out Xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4.5.0
       with:
         files: cobertura.xml
         fail_ci_if_error: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
